### PR TITLE
feat(observability): CloudWatch dashboard, alarms, 7d log retention, …

### DIFF
--- a/infra/live/dev/observability.tf
+++ b/infra/live/dev/observability.tf
@@ -1,0 +1,142 @@
+locals {
+  ingest_fn = module.ingest.function_name
+  worker_fn = module.worker.function_name
+  queue     = module.queue.queue_name
+}
+
+
+resource "aws_cloudwatch_log_group" "ingest" {
+  name              = "/aws/lambda/${local.ingest_fn}"
+  retention_in_days = 7
+}
+resource "aws_cloudwatch_log_group" "worker" {
+  name              = "/aws/lambda/${local.worker_fn}"
+  retention_in_days = 7
+}
+
+
+resource "aws_sns_topic" "ops" {
+  name = "ops-alerts-dev-sg1"
+}
+
+resource "aws_sns_topic_subscription" "ops_email" {
+  count     = var.alarm_email != "" ? 1 : 0
+  topic_arn = aws_sns_topic.ops.arn
+  protocol  = "email"
+  endpoint  = var.alarm_email
+}
+
+
+
+
+resource "aws_cloudwatch_metric_alarm" "sqs_age_high" {
+  alarm_name          = "dev-sg1-sqs-age>=60s-5m"
+  alarm_description   = "SQS oldest message age high (worker may be failing or behind)"
+  namespace           = "AWS/SQS"
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  statistic           = "Maximum"
+  period              = 60
+  evaluation_periods  = 5
+  threshold           = 60
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  dimensions = {
+    QueueName = local.queue
+  }
+  treat_missing_data = "notBreaching"
+  alarm_actions      = [aws_sns_topic.ops.arn]
+  ok_actions         = [aws_sns_topic.ops.arn]
+}
+
+
+resource "aws_cloudwatch_metric_alarm" "ingest_errors" {
+  alarm_name          = "dev-sg1-ingest-errors>=1-5m"
+  alarm_description   = "Ingest Lambda reported errors"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  period              = 60
+  evaluation_periods  = 5
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  dimensions = {
+    FunctionName = local.ingest_fn
+  }
+  treat_missing_data = "notBreaching"
+  alarm_actions      = [aws_sns_topic.ops.arn]
+  ok_actions         = [aws_sns_topic.ops.arn]
+}
+
+
+resource "aws_cloudwatch_metric_alarm" "worker_errors" {
+  alarm_name          = "dev-sg1-worker-errors>=1-5m"
+  alarm_description   = "Worker Lambda reported errors"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  period              = 60
+  evaluation_periods  = 5
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  dimensions = {
+    FunctionName = local.worker_fn
+  }
+  treat_missing_data = "notBreaching"
+  alarm_actions      = [aws_sns_topic.ops.arn]
+  ok_actions         = [aws_sns_topic.ops.arn]
+}
+
+
+resource "aws_cloudwatch_dashboard" "dev" {
+  dashboard_name = "event-dev-sg1"
+  dashboard_body = jsonencode({
+    widgets = [
+
+      {
+        "type" : "metric", "x" : 0, "y" : 0, "width" : 12, "height" : 6,
+        "properties" : {
+          "title" : "Lambda Invocations (ingest vs worker)",
+          "metrics" : [
+            ["AWS/Lambda", "Invocations", "FunctionName", local.ingest_fn],
+            [".", "Invocations", "FunctionName", local.worker_fn]
+          ],
+          "stat" : "Sum", "period" : 60, "region" : "ap-southeast-1", "view" : "timeSeries"
+        }
+      },
+      {
+        "type" : "metric", "x" : 12, "y" : 0, "width" : 12, "height" : 6,
+        "properties" : {
+          "title" : "Lambda Errors & Throttles",
+          "metrics" : [
+            ["AWS/Lambda", "Errors", "FunctionName", local.ingest_fn],
+            [".", "Errors", "FunctionName", local.worker_fn],
+            [".", "Throttles", "FunctionName", local.ingest_fn],
+            [".", "Throttles", "FunctionName", local.worker_fn]
+          ],
+          "stat" : "Sum", "period" : 60, "region" : "ap-southeast-1", "view" : "timeSeries"
+        }
+      },
+
+
+      {
+        "type" : "metric", "x" : 0, "y" : 6, "width" : 12, "height" : 6,
+        "properties" : {
+          "title" : "SQS Oldest Message Age (s)",
+          "metrics" : [
+            ["AWS/SQS", "ApproximateAgeOfOldestMessage", "QueueName", local.queue]
+          ],
+          "stat" : "Maximum", "period" : 60, "region" : "ap-southeast-1", "view" : "timeSeries"
+        }
+      },
+      {
+        "type" : "metric", "x" : 12, "y" : 6, "width" : 12, "height" : 6,
+        "properties" : {
+          "title" : "SQS Messages Visible",
+          "metrics" : [
+            ["AWS/SQS", "ApproximateNumberOfMessagesVisible", "QueueName", local.queue]
+          ],
+          "stat" : "Average", "period" : 60, "region" : "ap-southeast-1", "view" : "timeSeries"
+        }
+      }
+    ]
+  })
+}

--- a/infra/live/dev/variables.tf
+++ b/infra/live/dev/variables.tf
@@ -1,0 +1,5 @@
+variable "alarm_email" {
+  description = "Email to subscribe to ops alarms"
+  type        = string
+  default     = "" # fill in or override via -var
+}

--- a/infra/modules/sqs/main.tf
+++ b/infra/modules/sqs/main.tf
@@ -19,3 +19,5 @@ resource "aws_sqs_queue" "main" {
 output "queue_url" { value = aws_sqs_queue.main.id }
 output "queue_arn" { value = aws_sqs_queue.main.arn }
 output "dlq_arn"   { value = aws_sqs_queue.dlq.arn }
+output "queue_name" { value = aws_sqs_queue.main.name }
+


### PR DESCRIPTION
- Add 7d retention for /aws/lambda/ingest-dev-sg1 and /aws/lambda/worker-dev-sg1
- Create SNS topic (ops-alerts-dev-sg1) + optional email subscription (var.alarm_email)
- Add alarms: SQS oldest message age >= 60s for 5m; Lambda Errors >= 1 for 5m (ingest & worker)
- Create dashboard 'event-dev-sg1' with Lambda Invocations/Errors/Throttles and SQS Age/Visible panels
- Expose SQS queue_name output for metric dimensions (CloudWatch uses QueueName)